### PR TITLE
Shut up for an hour if the insult generator is failing.

### DIFF
--- a/scripts/abuse.coffee
+++ b/scripts/abuse.coffee
@@ -11,6 +11,8 @@ welcomes = [
   "Fuck off"
 ]
 
+noMoreComplainingUntil = null
+
 nameOf = (subject, robot, msg) ->
   subject = subject.trim()
   switch subject.toLowerCase()
@@ -41,7 +43,10 @@ insult = (msg, callback) ->
       if matches
         callback matches[1].toLowerCase()
       else
-        callback body
+        now = new Date().valueOf()
+        if noMoreComplainingUntil == null || now > noMoreComplainingUntil
+          callback "... well I'm speechless (because the insult generator is down)"
+          noMoreComplainingUntil = now + 3600000
 
 module.exports = (robot) ->
 


### PR DESCRIPTION
If the insult generator isn't working, tudebot dumps the entire error page into the channel. That's not ideal.

Instead, we could just go without an insult unless we haven't noticed the breakage for an hour.